### PR TITLE
Add Docker Compose setup for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to `.env` to override Docker Compose defaults.
+# Every value here is optional — the defaults below match the app's defaults.
+
+# --- Host ports ---
+# Change these only if a port is already taken on your machine.
+# Note: on macOS the AirPlay Receiver listens on 5000, so set SERVER_PORT=5001.
+SERVER_PORT=5000
+CLIENT_PORT=5173
+MONGO_PORT=27017
+
+# --- Secrets ---
+# Fine to leave as-is for local development. Change for anything public-facing.
+JWT_SECRET=dev-jwt-secret-change-in-production
+# Must be a non-empty string (used as the AES passphrase for stored API keys).
+ENCRYPTION_KEY=0123456789abcdef0123456789abcdef

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -165,7 +165,73 @@ wa-flow-builder/
 
 ---
 
-## 🚀 Getting Started
+## 🐳 Run with Docker (recommended)
+
+The fastest way to get the whole stack — **MongoDB + API + client** — running locally,
+with hot-reload on both the server and the client. The only prerequisite is
+[Docker](https://docs.docker.com/get-docker/) with Compose v2.
+
+```bash
+git clone https://github.com/theabhipatel/wa-flow-builder.git
+cd wa-flow-builder
+
+# Start everything (first run builds the images and installs dependencies)
+docker compose up --build
+
+# In another terminal, create the default users (one-time)
+docker compose exec server npm run seed
+```
+
+Then open **http://localhost:5173** and log in with the seeded account:
+
+| Role  | Email             | Password |
+|-------|-------------------|----------|
+| Admin | `admin@gmail.com` | `123456` |
+| User  | `abhi@gmail.com`  | `123456` |
+
+| Service      | URL                       |
+|--------------|---------------------------|
+| Client (UI)  | http://localhost:5173     |
+| API          | http://localhost:5000     |
+| MongoDB      | `mongodb://localhost:27017` |
+
+Source files are bind-mounted, so editing anything under `server/` or `client/`
+hot-reloads automatically — no rebuild needed.
+
+### Configuration
+
+All settings are optional and have sensible defaults. To override a port or a
+secret, copy the example env file and edit it:
+
+```bash
+cp .env.example .env
+```
+
+| Variable        | Default                            | Notes |
+|-----------------|------------------------------------|-------|
+| `SERVER_PORT`   | `5000`                             | **macOS:** the AirPlay Receiver also uses 5000 — set this to `5001` if the API port is busy. |
+| `CLIENT_PORT`   | `5173`                             | Vite dev server (the URL you open in the browser). |
+| `MONGO_PORT`    | `27017`                            | Host port for MongoDB. |
+| `JWT_SECRET`    | `dev-jwt-secret-change-in-production` | Change for anything public-facing. |
+| `ENCRYPTION_KEY`| 32-char dev key                    | AES passphrase for stored API keys. |
+
+### Common commands
+
+```bash
+docker compose up -d --build      # start in the background
+docker compose logs -f server     # tail the API logs
+docker compose exec server npm run seed   # (re)create the default users
+docker compose down               # stop (database is kept in a named volume)
+docker compose down -v            # stop and wipe the database
+```
+
+> The API connects to MongoDB over the internal Docker network. The browser runs
+> on the host, so the client is configured to reach the API via the published
+> `SERVER_PORT` — keep `SERVER_PORT` and the URL you open in sync.
+
+---
+
+## 🚀 Getting Started (manual / without Docker)
 
 ### Prerequisites
 

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+npm-debug.log

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY package*.json ./
+RUN npm install
+
+# Copy source
+COPY . .
+
+EXPOSE 5173
+
+# Vite dev server, exposed on all interfaces so the host can reach it
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+# Local development stack for WhatsApp Flow Builder.
+#
+#   docker compose up --build        # start everything (MongoDB + API + client)
+#   docker compose exec server npm run seed   # create the default admin user
+#
+# Ports and secrets can be overridden via a `.env` file in this directory
+# (copy .env.example to .env). Defaults match the app's own defaults.
+services:
+  mongo:
+    image: mongo:7
+    container_name: wafb-mongo
+    restart: unless-stopped
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  server:
+    build: ./server
+    container_name: wafb-server
+    restart: unless-stopped
+    depends_on:
+      mongo:
+        condition: service_healthy
+    environment:
+      MONGODB_URI: mongodb://mongo:27017/whatsapp_flow_builder
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-in-production}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef}
+      PORT: "5000"
+      NODE_ENV: development
+      CLIENT_URL: http://localhost:${CLIENT_PORT:-5173}
+    ports:
+      - "${SERVER_PORT:-5000}:5000"
+    volumes:
+      # Bind-mount source for hot-reload. node_modules lives in a named volume
+      # so it is NOT shadowed by the host mount; deps are installed into it on
+      # first start (and kept up to date) by the command below.
+      - ./server:/app
+      - server-node-modules:/app/node_modules
+    command: sh -c "npm install && npm run dev"
+
+  client:
+    build: ./client
+    container_name: wafb-client
+    restart: unless-stopped
+    depends_on:
+      - server
+    environment:
+      # The browser runs on the host, so it reaches the API via the published
+      # host port (not the internal docker network).
+      VITE_API_URL: http://localhost:${SERVER_PORT:-5000}
+    ports:
+      - "${CLIENT_PORT:-5173}:5173"
+    volumes:
+      - ./client:/app
+      - client-node-modules:/app/node_modules
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+
+volumes:
+  mongo-data:
+  server-node-modules:
+  client-node-modules:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+npm-debug.log

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY package*.json ./
+RUN npm install
+
+# Copy source
+COPY . .
+
+EXPOSE 5000
+
+# Dev mode with hot-reload via tsx watch
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## What

Adds a one-command Docker Compose setup so the full stack — **MongoDB + API + client** — comes up locally with hot-reload on both the server and the client. No code in the app itself is touched; this only adds infra files and a README section.

```bash
docker compose up --build
docker compose exec server npm run seed   # one-time: create default users
# open http://localhost:5173
```

## Changes

- **`docker-compose.yml`** — `mongo` + `server` + `client`. Source is bind-mounted for hot-reload; `node_modules` lives in named volumes (installed at container startup so the host mount doesn't shadow them). MongoDB has a healthcheck that the server waits on via `depends_on`.
- **`server/Dockerfile`, `client/Dockerfile`** + matching `.dockerignore` files.
- **`.env.example`** — optional overrides for ports and secrets. Defaults match the app's existing defaults. Documents the macOS AirPlay Receiver `:5000` conflict (set `SERVER_PORT=5001`).
- **`README.md`** — a "Run with Docker (recommended)" quick-start section above the existing manual instructions.
- **`.gitignore`** — ignore the Compose `.env` file.

## Notes

- The browser runs on the host, so the client reaches the API via the published `SERVER_PORT` (`VITE_API_URL`), while the server talks to Mongo over the internal Docker network.
- Verified end-to-end: stack boots, `/api/health` responds, seed creates the default users, admin login returns a token, and editing files under `server/`/`client/` triggers hot-reload.

